### PR TITLE
set router limit to 2000; bugfix to make it work with cron

### DIFF
--- a/create_community_files.js
+++ b/create_community_files.js
@@ -6,7 +6,7 @@ var moment = require('moment');
 var restClient = require('node-rest-client').Client;
 
 var options = {
-	netmonUrl: "https://netmon.freifunk-franken.de/api/rest/routerlist/?limit=1000",
+	netmonUrl: "https://netmon.freifunk-franken.de/api/rest/routerlist/?limit=2000",
 	communitysFile: 'communitys_franken.json',
 	outputDir: '../freifunkfranken-community/',
 	outputPrefix: '',

--- a/updateFromNetmon.sh
+++ b/updateFromNetmon.sh
@@ -1,21 +1,29 @@
 #!/bin/sh
 
-BASEDIR="$PWD"
-echo "BASEDIR: "."${BASEDIR}"
+#get BASEDIR properly for cron (http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in)
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+BASEDIR=$DIR
 
 # update community repository
-cd "${BASEDIR}/../freifunkfranken-community/"
+COMMUNITYDIR=$( dirname $BASEDIR )
+COMMUNITYDIR="${COMMUNITYDIR}/freifunkfranken-community/"
+cd ${COMMUNITYDIR}
 git pull
 
 # get all nodes from netmon and update the community files
-cd "${BASEDIR}"
+cd ${BASEDIR}
 git pull
-node ./create_community_files.js 
+CREATEFILE="${BASEDIR}/create_community_files.js"
+node ${CREATEFILE}
 
 # update the github repository with the new data
-cd "${BASEDIR}/../freifunkfranken-community/"
+cd ${COMMUNITYDIR}
 git config user.name "NetmonUpdateScript"
 git commit -a -m "updated from netmon"
 git push origin master
-cd "${BASEDIR}"
-


### PR DESCRIPTION
i made two changes to hopefully fix the issues we discussed:

routerlimit:
as we hit more than 1000 routers i increased the limit to crawl a maximum of 2000 routers

cron job:
the cron job could not determine the folder properly (as "pwd" seems not to work like when run as user in terminal)

all changes should be tested before merge. warranties excluded.
